### PR TITLE
[Cpp] Add nulls_first and asc flag to SortArraysToIndices

### DIFF
--- a/cpp/src/arrow/compute/kernels/sort_arrays_to_indices.h
+++ b/cpp/src/arrow/compute/kernels/sort_arrays_to_indices.h
@@ -51,7 +51,7 @@ struct ArrayItemIndex {
 ARROW_EXPORT
 Status SortArraysToIndices(FunctionContext* ctx,
                            std::vector<std::shared_ptr<Array>> values,
-                           std::shared_ptr<Array>* offsets);
+                           std::shared_ptr<Array>* offsets, bool nulls_first, bool asc);
 
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
Now we enabled arrow to support two configuration, check as below
[ RUN      ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsFirstASC

=============  Output is ===============
null null 1 2 3 4 6 7 8 9 10 11 12 13 14 15 17 18 19 20 21 22 23 30 32 33 35 37 41 42 43 50 50 59 64
[       OK ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsFirstASC (30 ms)
[ RUN      ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsLastASC

=============  Output is ===============
1 2 3 4 6 7 8 9 10 11 12 13 14 15 17 18 19 20 21 22 23 30 32 33 35 37 41 42 43 50 50 59 64 null null
[       OK ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsLastASC (0 ms)
[ RUN      ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsFirstDESC

=============  Output is ===============
null null 64 59 50 50 43 42 41 37 35 33 32 30 23 22 21 20 19 18 17 15 14 13 12 11 10 9 8 7 6 4 3 2 1
[       OK ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsFirstDESC (0 ms)
[ RUN      ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsLastDESC

=============  Output is ===============
64 59 50 50 43 42 41 37 35 33 32 30 23 22 21 20 19 18 17 15 14 13 12 11 10 9 8 7 6 4 3 2 1 null null
[       OK ] TestSortToIndicesKernelForIntegral/0.SortIntegralNullsLastDESC (0 ms)

Signed-off-by: Chendi Xue <chendi.xue@intel.com>