### PR TITLE
Modify VectorLoader to support native compression

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -53,12 +53,12 @@ public class VectorLoader {
    * @param recordBatch the batch to load
    */
   public void load(ArrowRecordBatch recordBatch) {
+    root.setRowCount(recordBatch.getLength());
     Iterator<ArrowBuf> buffers = recordBatch.getBuffers().iterator();
     Iterator<ArrowFieldNode> nodes = recordBatch.getNodes().iterator();
     for (FieldVector fieldVector : root.getFieldVectors()) {
       loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes);
     }
-    root.setRowCount(recordBatch.getLength());
     if (nodes.hasNext() || buffers.hasNext()) {
       throw new IllegalArgumentException("not all nodes and buffers were consumed. nodes: " +
           Collections2.toList(nodes).toString() + " buffers: " + Collections2.toList(buffers).toString());


### PR DESCRIPTION
This change wasn't accepted by arrow upstream because it may cause extra memory allocation for the compressed buffers. Since arrow's in the process of supporting compression for Java API, let's leave this as a temporary workaround.
more details: [ARROW-8672](https://issues.apache.org/jira/browse/ARROW-8672) [ARROW-8803](https://issues.apache.org/jira/browse/ARROW-8803)

@zhouyuan Please merge.