### PR TITLE
Remove compression workaround due to performance impact

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -53,12 +53,12 @@ public class VectorLoader {
    * @param recordBatch the batch to load
    */
   public void load(ArrowRecordBatch recordBatch) {
-    root.setRowCount(recordBatch.getLength());
     Iterator<ArrowBuf> buffers = recordBatch.getBuffers().iterator();
     Iterator<ArrowFieldNode> nodes = recordBatch.getNodes().iterator();
     for (FieldVector fieldVector : root.getFieldVectors()) {
       loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes);
     }
+    root.setRowCount(recordBatch.getLength());
     if (nodes.hasNext() || buffers.hasNext()) {
       throw new IllegalArgumentException("not all nodes and buffers were consumed. nodes: " +
           Collections2.toList(nodes).toString() + " buffers: " + Collections2.toList(buffers).toString());


### PR DESCRIPTION
Remove compression workaround due to performance impact. Based on discussion [Issue #63](https://github.com/Intel-bigdata/arrow/issues/63)

@zhouyuan Please merge.