### PR TITLE
Update the access permission from private to protected when deserialize stream

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
@@ -40,9 +40,9 @@ import io.netty.buffer.ArrowBuf;
  */
 public class ArrowStreamReader extends ArrowReader {
 
-  private MessageChannelReader messageReader;
+  protected MessageChannelReader messageReader;
 
-  private int loadedDictionaryCount;
+  protected int loadedDictionaryCount;
 
   /**
    * Constructs a streaming reader using a MessageChannelReader. Non-blocking.
@@ -137,7 +137,7 @@ public class ArrowStreamReader extends ArrowReader {
   /**
    * When read a record batch, check whether its dictionaries are available.
    */
-  private void checkDictionaries() throws IOException {
+  protected void checkDictionaries() throws IOException {
     // if all dictionaries are loaded, return.
     if (loadedDictionaryCount == dictionaries.size()) {
       return;
@@ -174,7 +174,7 @@ public class ArrowStreamReader extends ArrowReader {
   }
 
 
-  private ArrowDictionaryBatch readDictionary(MessageResult result) throws IOException {
+  protected ArrowDictionaryBatch readDictionary(MessageResult result) throws IOException {
 
     ArrowBuf bodyBuffer = result.getBodyBuffer();
 


### PR DESCRIPTION
In order to update the compress type based on the compressed size, we need pass the compress type from serialization side to deserialization end. So we need to update the access permission from private to protected. Then we can get the compress type passed by the serialization side.